### PR TITLE
angle() now returns the argument as is typically defined for complex numbers

### DIFF
--- a/Source/Complex.js
+++ b/Source/Complex.js
@@ -57,7 +57,7 @@ var prototype = Complex.prototype = {
 	},
 
 	angle: function(){
-		return Math.atan(this.im / this.real);
+		return Math.atan2(this.im, this.real);
 	},
 
 	conjungate: function(){

--- a/Specs/spec/Complex.js
+++ b/Specs/spec/Complex.js
@@ -36,6 +36,8 @@ describe('Complex', function(){
 
 	it('should calculate the angle between the real and the im vectors', function(){
 		expect(new Complex(1, 1).angle()).toEqual(Math.PI / 4);
+		expect(new Complex(-1, -1).angle()).toEqual(-3 * Math.PI / 4);
+		expect(new Complex(0, 1).angle()).toEqual(Math.PI / 2);
 		expect(new Complex(1, 0.5 * Math.sqrt(4 / 3)).angle()).toEqual(Math.PI / 6);
 		expect(new Complex(1, 0.5 * Math.sqrt(4 / 3)).arg()).toEqual(Math.PI / 6);
 	});


### PR DESCRIPTION
see http://mathworld.wolfram.com/ComplexArgument.html

Math.atan() ranges from -pi/2 to pi/2

Math.atan2() ranges from -pi to pi (the full unit circle), and handles
purely imaginary numbers correctly
