### PR TITLE
"module is undefined" when used in browser

### DIFF
--- a/lib/Complex.js
+++ b/lib/Complex.js
@@ -250,5 +250,6 @@ var cosh = function(x){
 	return (Math.pow(Math.E, x) + Math.pow(Math.E, -x)) / 2;
 };
 
-module.exports = Complex;
-
+if (typeof module !== 'undefined') {
+    module.exports = Complex;
+}


### PR DESCRIPTION
The final line of Complex.js sets "module.exports", but this fails if "module" is undefined.  The attached patch is a proposed fix.
